### PR TITLE
Pp 13499 Add Prometheus Logs

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -1,7 +1,8 @@
 import { FirehoseTransformationResult } from 'aws-lambda'
 
 import { handler } from './src'
-import { anApplicationLogCloudWatchEvent, anInvalidApplicationLogFirehoseTransformationEventRecord, mockContext, mockCallback } from './spec/fixtures'
+import { anApplicationLogCloudWatchEvent, anInvalidApplicationLogFirehoseTransformationEventRecord } from './spec/fixtures/application_fixtures'
+import { mockContext, mockCallback } from './spec/fixtures/general_fixtures'
 
 async function runDemo() {
   console.log('Starting demo...')

--- a/spec/fixtures/application_fixtures.ts
+++ b/spec/fixtures/application_fixtures.ts
@@ -1,0 +1,142 @@
+import { FirehoseTransformationEventRecord } from 'aws-lambda'
+import { Fixture } from './general_fixtures'
+
+export const anInvalidApplicationLogFirehoseTransformationEventRecord: FirehoseTransformationEventRecord = {
+  approximateArrivalTimestamp: 1234,
+  recordId: 'InvalidLogEvent-1',
+  data: Buffer.from(JSON.stringify({
+    owner: '223851549868',
+    logGroup: 'badLogGroupName',
+    logStream: 'frontendECSTaskId',
+    subscriptionFilters: [],
+    messageType: 'DATA_MESSAGE',
+    logEvents: [
+      {
+        id: 'cloudwatch-log-message-id-1',
+        timestamp: '1234',
+        message: 'Log event message 1'
+      },
+      {
+        id: 'cloudwatch-log-gmessage-id-2',
+        timestamp: '12345',
+        message: 'Log event message 2'
+      }
+    ]
+  })).toString('base64')
+}
+
+export const anApplicationLogCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_app_frontend',
+        logStream: 'frontendECSTaskId',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Log event message 1'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Log event message 2'
+          }
+        ]
+      })).toString('base64')
+    },
+    {
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-2',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_app_connector',
+        logStream: 'connectorECSTaskId',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Log event message 1'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Log event message 2'
+          }
+        ]
+      })).toString('base64')
+    }
+    ]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'frontendECSTaskId',
+          source: 'app',
+          sourcetype: 'ST004:application_json',
+          index: 'pay_application',
+          event: 'Log event message 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        },
+        {
+          host: 'frontendECSTaskId',
+          source: 'app',
+          sourcetype: 'ST004:application_json',
+          index: 'pay_application',
+          event: 'Log event message 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }, {
+      result: 'Ok',
+      recordId: 'LogEvent-2',
+      data: Buffer.from([
+        {
+          host: 'connectorECSTaskId',
+          source: 'app',
+          sourcetype: 'ST004:application_json',
+          index: 'pay_application',
+          event: 'Log event message 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'connector'
+          }
+        },
+        {
+          host: 'connectorECSTaskId',
+          source: 'app',
+          sourcetype: 'ST004:application_json',
+          index: 'pay_application',
+          event: 'Log event message 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'connector'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -1,0 +1,340 @@
+import { Fixture } from './general_fixtures'
+
+export const aConcourseSyslogCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_syslog_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 10:16:36 ip-10-1-10-72 check-available-memory[2996]: Calculated memory available: 72.6612%'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Feb 10 10:16:36 ip-10-1-10-72 systemd[1]: check-available-memory.service: Deactivated successfully.'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'syslog',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:16:36 ip-10-1-10-72 check-available-memory[2996]: Calculated memory available: 72.6612%',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        },
+        {
+          host: 'logStream',
+          source: 'syslog',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:16:36 ip-10-1-10-72 systemd[1]: check-available-memory.service: Deactivated successfully.',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseAuditCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_audit_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'type=SERVICE_STOP msg=audit(1739184096.304:468): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'unit=check-available-memory comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success\''
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'audit',
+          sourcetype: 'linux_audit',
+          index: 'pay_devops',
+          event: 'type=SERVICE_STOP msg=audit(1739184096.304:468): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'unit=check-available-memory comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success\'',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseAuthCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_auth_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 03:10:38 ip-10-1-11-65 sshd[635]: Server listening on :: port 22.'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'auth',
+          sourcetype: 'linux_secure',
+          index: 'pay_devops',
+          event: 'Feb 10 03:10:38 ip-10-1-11-65 sshd[635]: Server listening on :: port 22.',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseKernCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_kern_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 10:59:50 ip-10-1-10-215 kernel: [28395.086087] concourse0: port 25(veth2d1be85e) entered blocking state'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'kern',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:59:50 ip-10-1-10-215 kernel: [28395.086087] concourse0: port 25(veth2d1be85e) entered blocking state',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseDmesgCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_dmesg_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'dmesg',
+          sourcetype: 'dmesg',
+          index: 'pay_devops',
+          event: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseAptCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_apt_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Commandline: apt-get install --yes auditd'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'apt',
+          sourcetype: 'generic_single_line',
+          index: 'pay_devops',
+          event: 'Commandline: apt-get install --yes auditd',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aConcourseApplicationCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-concourse_concourse_concourse',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '{"timestamp":"2025-02-10T11:50:15.965132255Z","level":"info","source":"baggageclaim","message":"baggageclaim.api.volume-server.destroy.destroy-volume.destroyed","data":{"session":"4.1.49535.1","volume":"4da70dbf-66de-4f75-76b0-654e2fa32268"}}'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'concourse',
+          sourcetype: 'ST004:concourse',
+          index: 'pay_devops',
+          event: '{"timestamp":"2025-02-10T11:50:15.965132255Z","level":"info","source":"baggageclaim","message":"baggageclaim.api.volume-server.destroy.destroy-volume.destroyed","data":{"session":"4.1.49535.1","volume":"4da70dbf-66de-4f75-76b0-654e2fa32268"}}',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'concourse'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/fixtures/general_fixtures.ts
+++ b/spec/fixtures/general_fixtures.ts
@@ -1,6 +1,6 @@
 import { Callback, Context, FirehoseTransformationEventRecord, FirehoseTransformationEvent, FirehoseTransformationResult } from 'aws-lambda'
 
-type Fixture = {
+export type Fixture = {
   input: FirehoseTransformationEvent
   expected: FirehoseTransformationResult
 }

--- a/spec/fixtures/nginx_fixtures.ts
+++ b/spec/fixtures/nginx_fixtures.ts
@@ -1,0 +1,127 @@
+import { Fixture } from './general_fixtures'
+
+export const anNginxForwardProxyCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_nginx-forward-proxy_frontend',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Log event message 1'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Log event message 2'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'nginx-forward-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: 'Log event message 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-forward-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: 'Log event message 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const anNginxReverseProxyCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_nginx-reverse-proxy_frontend',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Log event message 1'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Log event message 2'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: 'Log event message 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: 'Log event message 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -1,0 +1,294 @@
+import { Fixture } from './general_fixtures'
+
+export const aPrometheusSyslogCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_syslog_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 10:16:36 ip-10-1-10-72 check-available-memory[2996]: Calculated memory available: 72.6612%'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: 'Feb 10 10:16:36 ip-10-1-10-72 systemd[1]: check-available-memory.service: Deactivated successfully.'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'syslog',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:16:36 ip-10-1-10-72 check-available-memory[2996]: Calculated memory available: 72.6612%',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        },
+        {
+          host: 'logStream',
+          source: 'syslog',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:16:36 ip-10-1-10-72 systemd[1]: check-available-memory.service: Deactivated successfully.',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aPrometheusAuditCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_audit_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'type=SERVICE_STOP msg=audit(1739184096.304:468): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'unit=check-available-memory comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success\''
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'audit',
+          sourcetype: 'linux_audit',
+          index: 'pay_devops',
+          event: 'type=SERVICE_STOP msg=audit(1739184096.304:468): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'unit=check-available-memory comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success\'',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aPrometheusAuthCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_auth_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 03:10:38 ip-10-1-11-65 sshd[635]: Server listening on :: port 22.'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'auth',
+          sourcetype: 'linux_secure',
+          index: 'pay_devops',
+          event: 'Feb 10 03:10:38 ip-10-1-11-65 sshd[635]: Server listening on :: port 22.',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aPrometheusKernCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_kern_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Feb 10 10:59:50 ip-10-1-10-215 kernel: [28395.086087] prometheus0: port 25(veth2d1be85e) entered blocking state'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'kern',
+          sourcetype: 'linux_messages_syslog',
+          index: 'pay_devops',
+          event: 'Feb 10 10:59:50 ip-10-1-10-215 kernel: [28395.086087] prometheus0: port 25(veth2d1be85e) entered blocking state',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aPrometheusDmesgCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_dmesg_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'dmesg',
+          sourcetype: 'dmesg',
+          index: 'pay_devops',
+          event: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aPrometheusAptCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'pay-cd-prometheus_apt_prometheus',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: 'Commandline: apt-get install --yes auditd'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'apt',
+          sourcetype: 'generic_single_line',
+          index: 'pay_devops',
+          event: 'Commandline: apt-get install --yes auditd',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'prometheus'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/fixtures/s3_fixtures.ts
+++ b/spec/fixtures/s3_fixtures.ts
@@ -1,0 +1,107 @@
+import { Fixture } from './general_fixtures'
+
+export const anS3AlbEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify(
+        {
+          SourceFile: {
+            S3Bucket: 'some-source-bucket',
+            S3Key: 'some-source-key'
+          },
+          ALB: 'test-12-connector-alb',
+          AWSAccountID: '223851549868',
+          AWSAccountName: 'pay-test',
+          Logs: ['alb log line 1', 'alb log line 2']
+        }
+      )).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'test-12-connector-alb',
+          source: 'ALB',
+          sourcetype: 'aws:elb:accesslogs',
+          index: 'pay_ingress',
+          event: 'alb log line 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          }
+        }, {
+          host: 'test-12-connector-alb',
+          source: 'ALB',
+          sourcetype: 'aws:elb:accesslogs',
+          index: 'pay_ingress',
+          event: 'alb log line 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const anS3AccessEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify(
+        {
+          SourceFile: {
+            S3Bucket: 'some-source-bucket',
+            S3Key: 'some-source-key'
+          },
+          S3Bucket: 'the-actual-bucket',
+          AWSAccountID: '223851549868',
+          AWSAccountName: 'pay-test',
+          Logs: ['log line 1', 'log line 2']
+        }
+      )).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'the-actual-bucket',
+          source: 'S3',
+          sourcetype: 'aws:s3:accesslogs',
+          index: 'pay_storage',
+          event: 'log line 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          }
+        }, {
+          host: 'the-actual-bucket',
+          source: 'S3',
+          sourcetype: 'aws:s3:accesslogs',
+          index: 'pay_storage',
+          event: 'log line 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -24,99 +24,105 @@ process.env.ENVIRONMENT = 'test-12'
 process.env.ACCOUNT = 'test'
 
 describe('Processing CloudWatchLogEvents', () => {
-  test('should transform application logs from CloudWatch', async () => {
-    const result = await handler(anApplicationLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+  describe('From Applications', () => {
+    test('should transform application logs from CloudWatch', async () => {
+      const result = await handler(anApplicationLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expectedFirstRecord = anApplicationLogCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expectedFirstRecord.result)
-    expect(result.records[0].recordId).toEqual(expectedFirstRecord.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expectedFirstRecord.data as string, 'base64').toString())
+      const expectedFirstRecord = anApplicationLogCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expectedFirstRecord.result)
+      expect(result.records[0].recordId).toEqual(expectedFirstRecord.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expectedFirstRecord.data as string, 'base64').toString())
 
-    const expectedSecondRecord = anApplicationLogCloudWatchEvent.expected.records[1]
-    expect(result.records[1].result).toEqual('Ok')
-    expect(result.records[1].recordId).toEqual('LogEvent-2')
-    expect(Buffer.from(result.records[1].data as string, 'base64').toString()).toEqual(Buffer.from(expectedSecondRecord.data as string, 'base64').toString())
+      const expectedSecondRecord = anApplicationLogCloudWatchEvent.expected.records[1]
+      expect(result.records[1].result).toEqual('Ok')
+      expect(result.records[1].recordId).toEqual('LogEvent-2')
+      expect(Buffer.from(result.records[1].data as string, 'base64').toString()).toEqual(Buffer.from(expectedSecondRecord.data as string, 'base64').toString())
+    })
   })
 
-  test('should transform nginx forward proxy logs from CloudWatch', async () => {
-    const result = await handler(anNginxForwardProxyCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+  describe('From Nginx', () => {
+    test('should transform nginx forward proxy logs from CloudWatch', async () => {
+      const result = await handler(anNginxForwardProxyCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = anNginxForwardProxyCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+      const expected = anNginxForwardProxyCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform nginx reverse proxy logs from CloudWatch', async () => {
+      const result = await handler(anNginxReverseProxyCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = anNginxReverseProxyCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
   })
 
-  test('should transform nginx reverse proxy logs from CloudWatch', async () => {
-    const result = await handler(anNginxReverseProxyCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+  describe('From Concourse', () => {
+    test('should transform concourse syslog logs from CloudWatch', async () => {
+      const result = await handler(aConcourseSyslogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = anNginxReverseProxyCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseSyslogCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse syslog logs from CloudWatch', async () => {
-    const result = await handler(aConcourseSyslogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse audit logs from CloudWatch', async () => {
+      const result = await handler(aConcourseAuditCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseSyslogCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseAuditCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse audit logs from CloudWatch', async () => {
-    const result = await handler(aConcourseAuditCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse auth logs from CloudWatch', async () => {
+      const result = await handler(aConcourseAuthCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseAuditCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseAuthCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse auth logs from CloudWatch', async () => {
-    const result = await handler(aConcourseAuthCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse kern logs from CloudWatch', async () => {
+      const result = await handler(aConcourseKernCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseAuthCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseKernCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse kern logs from CloudWatch', async () => {
-    const result = await handler(aConcourseKernCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse dmesg logs from CloudWatch', async () => {
+      const result = await handler(aConcourseDmesgCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseKernCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseDmesgCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse dmesg logs from CloudWatch', async () => {
-    const result = await handler(aConcourseDmesgCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse apt logs from CloudWatch', async () => {
+      const result = await handler(aConcourseAptCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseDmesgCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
+      const expected = aConcourseAptCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
 
-  test('should transform concourse apt logs from CloudWatch', async () => {
-    const result = await handler(aConcourseAptCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    test('should transform concourse application logs from CloudWatch', async () => {
+      const result = await handler(aConcourseApplicationCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
-    const expected = aConcourseAptCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
-  })
-
-  test('should transform concourse application logs from CloudWatch', async () => {
-    const result = await handler(aConcourseApplicationCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
-
-    const expected = aConcourseApplicationCloudWatchEvent.expected.records[0]
-    expect(result.records[0].result).toEqual(expected.result)
-    expect(result.records[0].recordId).toEqual(expected.recordId)
-    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+      const expected = aConcourseApplicationCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
   })
 
   test('should drop CloudWatch logs which are not DATA_MESSAGE', async () => {

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -3,14 +3,10 @@ import { handler } from '../src/index'
 
 import {
   anApplicationLogCloudWatchEvent,
-  aCloudWatchEventWith,
-  anInvalidApplicationLogFirehoseTransformationEventRecord,
-  anNginxForwardProxyCloudWatchEvent,
-  anNginxReverseProxyCloudWatchEvent,
-  anS3AlbEvent,
-  anS3AccessEvent,
-  mockCallback,
-  mockContext,
+  anInvalidApplicationLogFirehoseTransformationEventRecord
+} from './fixtures/application_fixtures'
+
+import {
   aConcourseSyslogCloudWatchEvent,
   aConcourseAuditCloudWatchEvent,
   aConcourseAuthCloudWatchEvent,
@@ -18,7 +14,23 @@ import {
   aConcourseDmesgCloudWatchEvent,
   aConcourseAptCloudWatchEvent,
   aConcourseApplicationCloudWatchEvent
-} from './fixtures'
+} from './fixtures/concourse_fixtures'
+
+import {
+  anS3AlbEvent,
+  anS3AccessEvent
+} from './fixtures/s3_fixtures'
+
+import {
+  anNginxForwardProxyCloudWatchEvent,
+  anNginxReverseProxyCloudWatchEvent
+} from './fixtures/nginx_fixtures'
+
+import {
+  aCloudWatchEventWith,
+  mockCallback,
+  mockContext
+} from './fixtures/general_fixtures'
 
 process.env.ENVIRONMENT = 'test-12'
 process.env.ACCOUNT = 'test'

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -17,6 +17,15 @@ import {
 } from './fixtures/concourse_fixtures'
 
 import {
+  aPrometheusSyslogCloudWatchEvent,
+  aPrometheusAuditCloudWatchEvent,
+  aPrometheusAuthCloudWatchEvent,
+  aPrometheusKernCloudWatchEvent,
+  aPrometheusDmesgCloudWatchEvent,
+  aPrometheusAptCloudWatchEvent
+} from './fixtures/prometheus_fixtures'
+
+import {
   anS3AlbEvent,
   anS3AccessEvent
 } from './fixtures/s3_fixtures'
@@ -131,6 +140,62 @@ describe('Processing CloudWatchLogEvents', () => {
       const result = await handler(aConcourseApplicationCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
       const expected = aConcourseApplicationCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+  })
+
+  describe('From Prometheus', () => {
+    test('should transform prometheus syslog logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusSyslogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusSyslogCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform prometheus audit logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusAuditCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusAuditCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform prometheus auth logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusAuthCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusAuthCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform prometheus kern logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusKernCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusKernCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform prometheus dmesg logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusDmesgCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusDmesgCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+
+    test('should transform prometheus apt logs from CloudWatch', async () => {
+      const result = await handler(aPrometheusAptCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aPrometheusAptCloudWatchEvent.expected.records[0]
       expect(result.records[0].result).toEqual(expected.result)
       expect(result.records[0].recordId).toEqual(expected.recordId)
       expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())


### PR DESCRIPTION
Some refactoring in the first two commits to arrange test code and fixtures to make it clearer when adding in the prometheus transformations and tests in the final commit.

@jfharden and I checked and the prometheus application logs are just going to syslog unlike for concourse where we split them out.