### PR TITLE
PP-13499 Add CloudTrail Transformation

### DIFF
--- a/spec/fixtures/cloudtrail_fixtures.ts
+++ b/spec/fixtures/cloudtrail_fixtures.ts
@@ -1,0 +1,60 @@
+import { Fixture } from './general_fixtures'
+
+export const aCloudTrailLogCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test_cloudtrail',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '{"eventVersion":"REDACTED","userIdentity":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","userName":"REDACTED"},"attributes":{"creationDate":"REDACTED","mfaAuthenticated":"REDACTED"}},"inScopeOf":{"issuerType":"REDACTED","credentialsIssuedTo":"REDACTED"}},"eventTime":"REDACTED","eventSource":"REDACTED","eventName":"REDACTED","awsRegion":"REDACTED","sourceIPAddress":"REDACTED","userAgent":"REDACTED","requestParameters":{"trailNameList":[],"includeShadowTrails":"REDACTED"},"responseElements":"REDACTED","requestID":"REDACTED","eventID":"REDACTED","readOnly":"REDACTED","eventType":"REDACTED","managementEvent":"REDACTED","recipientAccountId":"REDACTED","eventCategory":"REDACTED","tlsDetails":{"tlsVersion":"REDACTED","cipherSuite":"REDACTED","clientProvidedHostHeader":"REDACTED"}}'
+          },
+          {
+            id: 'cloudwatch-log-gmessage-id-2',
+            timestamp: '12345',
+            message: '{"eventVersion":"REDACTED","userIdentity":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","userName":"REDACTED"},"attributes":{"creationDate":"REDACTED","mfaAuthenticated":"REDACTED"}},"inScopeOf":{"issuerType":"REDACTED","credentialsIssuedTo":"REDACTED"}},"eventTime":"REDACTED","eventSource":"REDACTED","eventName":"REDACTED","awsRegion":"REDACTED","sourceIPAddress":"REDACTED","userAgent":"REDACTED","requestParameters":{"trailNameList":[],"includeShadowTrails":"REDACTED"},"responseElements":"REDACTED","requestID":"REDACTED","eventID":"REDACTED","readOnly":"REDACTED","eventType":"REDACTED","managementEvent":"REDACTED","recipientAccountId":"REDACTED","eventCategory":"REDACTED","tlsDetails":{"tlsVersion":"REDACTED","cipherSuite":"REDACTED","clientProvidedHostHeader":"REDACTED"}}'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'test',
+          source: 'cloudtrail',
+          sourcetype: 'aws:cloudtrail',
+          index: 'pay_platform',
+          event: '{"eventVersion":"REDACTED","userIdentity":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","userName":"REDACTED"},"attributes":{"creationDate":"REDACTED","mfaAuthenticated":"REDACTED"}},"inScopeOf":{"issuerType":"REDACTED","credentialsIssuedTo":"REDACTED"}},"eventTime":"REDACTED","eventSource":"REDACTED","eventName":"REDACTED","awsRegion":"REDACTED","sourceIPAddress":"REDACTED","userAgent":"REDACTED","requestParameters":{"trailNameList":[],"includeShadowTrails":"REDACTED"},"responseElements":"REDACTED","requestID":"REDACTED","eventID":"REDACTED","readOnly":"REDACTED","eventType":"REDACTED","managementEvent":"REDACTED","recipientAccountId":"REDACTED","eventCategory":"REDACTED","tlsDetails":{"tlsVersion":"REDACTED","cipherSuite":"REDACTED","clientProvidedHostHeader":"REDACTED"}}',
+          fields: {
+            account: 'test'
+          }
+        },
+        {
+          host: 'test',
+          source: 'cloudtrail',
+          sourcetype: 'aws:cloudtrail',
+          index: 'pay_platform',
+          event: '{"eventVersion":"REDACTED","userIdentity":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","accessKeyId":"REDACTED","sessionContext":{"sessionIssuer":{"type":"REDACTED","principalId":"REDACTED","arn":"REDACTED","accountId":"REDACTED","userName":"REDACTED"},"attributes":{"creationDate":"REDACTED","mfaAuthenticated":"REDACTED"}},"inScopeOf":{"issuerType":"REDACTED","credentialsIssuedTo":"REDACTED"}},"eventTime":"REDACTED","eventSource":"REDACTED","eventName":"REDACTED","awsRegion":"REDACTED","sourceIPAddress":"REDACTED","userAgent":"REDACTED","requestParameters":{"trailNameList":[],"includeShadowTrails":"REDACTED"},"responseElements":"REDACTED","requestID":"REDACTED","eventID":"REDACTED","readOnly":"REDACTED","eventType":"REDACTED","managementEvent":"REDACTED","recipientAccountId":"REDACTED","eventCategory":"REDACTED","tlsDetails":{"tlsVersion":"REDACTED","cipherSuite":"REDACTED","clientProvidedHostHeader":"REDACTED"}}',
+          fields: {
+            account: 'test'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -47,6 +47,7 @@ import {
   mockCallback,
   mockContext
 } from './fixtures/general_fixtures'
+import { aCloudTrailLogCloudWatchEvent } from './fixtures/cloudtrail_fixtures'
 
 process.env.ENVIRONMENT = 'test-12'
 process.env.ACCOUNT = 'test'
@@ -241,6 +242,17 @@ describe('Processing CloudWatchLogEvents', () => {
       const result = await handler(aSquidWebhookEgressCacheLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
       const expected = aSquidWebhookEgressCacheLogCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+  })
+
+  describe('From CloudTrail', () => {
+    test('should transform cloudtrail logs from CloudWatch', async () => {
+      const result = await handler(aCloudTrailLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = aCloudTrailLogCloudWatchEvent.expected.records[0]
       expect(result.records[0].result).toEqual(expected.result)
       expect(result.records[0].recordId).toEqual(expected.recordId)
       expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())


### PR DESCRIPTION
Add the cloudtrail transformation, note that these are account wide so the environment field is not sent.

Felt safer to redact all leaf values in the fixture than accidentally miss something sensitive, if future testing needs some values we can add them in as necessary... e.g. when we come to parse time stamps.