### PR TITLE
PP-13499 VPC flow logs

### DIFF
--- a/spec/fixtures/vpcflowlog_fixtures.ts
+++ b/spec/fixtures/vpcflowlog_fixtures.ts
@@ -1,0 +1,112 @@
+import { Fixture } from './general_fixtures'
+
+export const aMultiLogVpcFlowLogCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'mixed-protocol-event',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_vpc-flow-logs',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 6 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is TCP
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 1 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is ICMP
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 17 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is UDP
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 2 17 5466 1739358222 1739358234 REJECT OK' // <-- filtered because it is REJECT
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 2 17 5466 1739358222 1739358234 ACCEPT OK' // <-- This should go to Splunk
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'mixed-protocol-event',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'vpc-flow-logs',
+          sourcetype: 'aws:cloudwatchlogs:vpcflow',
+          index: 'pay_platform',
+          event: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 2 17 5466 1739358222 1739358234 ACCEPT OK',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const aMultiLogVpcFlowLogAllFilteredCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'some-id',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'record-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_vpc-flow-logs',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 6 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is TCP
+
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 1 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is ICMP
+
+          },
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: '1234',
+            message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 17 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is UDP
+
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Dropped',
+      recordId: 'record-1',
+      data: Buffer.from('').toString('base64')
+    }]
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import {
   FirehoseTransformationEvent, FirehoseTransformationResult, FirehoseTransformationResultRecord
 } from 'aws-lambda'
 
+type TransformationResult = {
+  result: 'Ok' | 'Dropped' | 'ProcessingFailed'
+  splunkRecords: SplunkRecord[]
+}
+
 type SplunkRecord = {
   host: string
   source: string
@@ -49,7 +54,8 @@ enum CloudWatchLogTypes {
   'nginx-forward-proxy',
   'nginx-reverse-proxy',
   'syslog',
-  'squid'
+  'squid',
+  'vpc-flow-logs'
 }
 
 const SQUID_ACCESS_LOG_FORMAT_REGEX = /^\d+\.\d{3} /
@@ -85,6 +91,8 @@ function sourceTypeFromLogGroup(logType: CloudWatchLogTypes, msg: string): strin
       return squidSourceType(msg)
     case CloudWatchLogTypes['cloudtrail']:
       return 'aws:cloudtrail'
+    case CloudWatchLogTypes['vpc-flow-logs']:
+      return 'aws:cloudwatchlogs:vpcflow'
   }
 }
 
@@ -106,6 +114,7 @@ function indexFromLogType(logType: CloudWatchLogTypes): string {
     case CloudWatchLogTypes['squid']:
       return 'pay_egress'
     case CloudWatchLogTypes['cloudtrail']:
+    case CloudWatchLogTypes['vpc-flow-logs']:
       return 'pay_platform'
   }
 }
@@ -131,7 +140,14 @@ function getServiceFromLogGroup(logGroup: string): string | undefined {
   }
 }
 
-function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVars): SplunkRecord[] {
+function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVars): TransformationResult {
+  if (data.messageType !== 'DATA_MESSAGE') {
+    return {
+      result: 'Dropped',
+      splunkRecords: []
+    }
+  }
+
   validateLogGroup(data.logGroup)
 
   const logType: CloudWatchLogTypes = getLogTypeFromLogGroup(data.logGroup)
@@ -152,58 +168,60 @@ function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVa
     fields.service = service
   }
 
-  return data.logEvents.map((event) => {
-    return {
-      host,
-      source,
-      sourcetype: sourceTypeFromLogGroup(logType, event.message),
-      index,
-      event: event.message,
-      fields
-    }
-  })
-}
-
-function transformALBLog(data: S3LogRecord, envVars: EnvVars): SplunkRecord[] {
-  return data.Logs.map((log) => {
-    return {
-      host: data.ALB as string,
-      source: 'ALB',
-      sourcetype: 'aws:elb:accesslogs',
-      index: 'pay_ingress',
-      event: log,
-      fields: {
-        account: envVars.account,
-        environment: envVars.environment
+  return {
+    result: 'Ok',
+    splunkRecords: data.logEvents.map((event) => {
+      return {
+        host,
+        source,
+        sourcetype: sourceTypeFromLogGroup(logType, event.message),
+        index,
+        event: event.message,
+        fields
       }
-    }
-  })
-}
-
-function transformS3AccessLog(data: S3LogRecord, envVars: EnvVars): SplunkRecord[] {
-  return data.Logs.map((log) => {
-    return {
-      host: data.S3Bucket as string,
-      source: 'S3',
-      sourcetype: 'aws:s3:accesslogs',
-      index: 'pay_storage',
-      event: log,
-      fields: {
-        account: envVars.account,
-        environment: envVars.environment
-      }
-    }
-  })
-}
-
-function shouldDropRecord(data: object): boolean {
-  if ('messageType' in data && data.messageType !== 'DATA_MESSAGE') {
-    return true
+    })
   }
-  return false
 }
 
-function transformData(data: object, envVars: EnvVars): SplunkRecord[] {
+function transformALBLog(data: S3LogRecord, envVars: EnvVars): TransformationResult {
+  return {
+    result: 'Ok',
+    splunkRecords: data.Logs.map((log) => {
+      return {
+        host: data.ALB as string,
+        source: 'ALB',
+        sourcetype: 'aws:elb:accesslogs',
+        index: 'pay_ingress',
+        event: log,
+        fields: {
+          account: envVars.account,
+          environment: envVars.environment
+        }
+      }
+    })
+  }
+}
+
+function transformS3AccessLog(data: S3LogRecord, envVars: EnvVars): TransformationResult {
+  return {
+    result: 'Ok',
+    splunkRecords: data.Logs.map((log) => {
+      return {
+        host: data.S3Bucket as string,
+        source: 'S3',
+        sourcetype: 'aws:s3:accesslogs',
+        index: 'pay_storage',
+        event: log,
+        fields: {
+          account: envVars.account,
+          environment: envVars.environment
+        }
+      }
+    })
+  }
+}
+
+function transformData(data: object, envVars: EnvVars): TransformationResult {
   if ('logGroup' in data) {
     return transformCloudWatchData(data as CloudWatchLogsDecodedData, envVars)
   } else if ('ALB' in data) {
@@ -246,21 +264,13 @@ export const handler: FirehoseTransformationHandler = async (event: FirehoseTran
         throw new Error('The record data could not be parsed as an object')
       }
 
-      if (shouldDropRecord(recordData)) {
-        records.push({
-          recordId: record.recordId,
-          result: 'Dropped',
-          data: record.data
-        })
-      } else {
-        const transformedData = transformData(recordData, envVars)
-        const joinedData = transformedData.map(x => JSON.stringify(x)).join('\n')
-        records.push({
-          recordId: record.recordId,
-          result: 'Ok',
-          data: Buffer.from(joinedData).toString('base64')
-        })
-      }
+      const transformedData = transformData(recordData, envVars)
+      const joinedData = transformedData.splunkRecords.map(x => JSON.stringify(x)).join('\n')
+      records.push({
+        recordId: record.recordId,
+        result: transformedData.result,
+        data: Buffer.from(joinedData).toString('base64')
+      })
     } catch (e) {
       let errorMessage: string
 


### PR DESCRIPTION
Refactor to permit filtering of individual log lines within an event record. Following existing filtering VPC flow logs will only be sent to Splunk if the connection was accepted and not using TCP, UDP or ICMP protocols.

### NOTES ###
Based upon this existing logic for filtering out vpc flow logs: https://github.com/alphagov/pay-cloudwatch-logs-s3-export/blob/main/exports.js#L119
