### PR TITLE
PP-13499 Extract ALB Service Name

### DIFF
--- a/spec/fixtures/s3_fixtures.ts
+++ b/spec/fixtures/s3_fixtures.ts
@@ -14,7 +14,7 @@ export const anS3AlbEvent: Fixture = {
             S3Bucket: 'some-source-bucket',
             S3Key: 'some-source-key'
           },
-          ALB: 'test-12-connector-alb',
+          ALB: 'test-12-products-ui-alb',
           AWSAccountID: '223851549868',
           AWSAccountName: 'pay-test',
           Logs: ['alb log line 1', 'alb log line 2']
@@ -28,24 +28,81 @@ export const anS3AlbEvent: Fixture = {
       recordId: 'LogEvent-1',
       data: Buffer.from([
         {
-          host: 'test-12-connector-alb',
+          host: 'test-12-products-ui-alb',
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
           event: 'alb log line 1',
           fields: {
             account: 'test',
-            environment: 'test-12'
+            environment: 'test-12',
+            service: 'products-ui'
           }
         }, {
-          host: 'test-12-connector-alb',
+          host: 'test-12-products-ui-alb',
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
           event: 'alb log line 2',
           fields: {
             account: 'test',
-            environment: 'test-12'
+            environment: 'test-12',
+            service: 'products-ui'
+          }
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}
+
+export const anS3AlbPactbrokerEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify(
+        {
+          SourceFile: {
+            S3Bucket: 'some-source-bucket',
+            S3Key: 'some-source-key'
+          },
+          ALB: 'test-12-tooling-pactbroker-alb',
+          AWSAccountID: '223851549868',
+          AWSAccountName: 'pay-test',
+          Logs: ['alb log line 1', 'alb log line 2']
+        }
+      )).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'test-12-tooling-pactbroker-alb',
+          source: 'ALB',
+          sourcetype: 'aws:elb:accesslogs',
+          index: 'pay_ingress',
+          event: 'alb log line 1',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'pactbroker'
+          }
+        }, {
+          host: 'test-12-tooling-pactbroker-alb',
+          source: 'ALB',
+          sourcetype: 'aws:elb:accesslogs',
+          index: 'pay_ingress',
+          event: 'alb log line 2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'pactbroker'
           }
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -27,7 +27,8 @@ import {
 
 import {
   anS3AlbEvent,
-  anS3AccessEvent
+  anS3AccessEvent,
+  anS3AlbPactbrokerEvent
 } from './fixtures/s3_fixtures'
 
 import {
@@ -303,10 +304,18 @@ describe('Processing CloudWatchLogEvents', () => {
 
 describe('Processing S3 Logs', () => {
   test('should transform ALB log from S3', async () => {
-    // noinspection TypeScriptValidateTypes
     const result = await handler(anS3AlbEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
     const expected = anS3AlbEvent.expected.records[0]
+    expect(result.records[0].result).toEqual(expected.result)
+    expect(result.records[0].recordId).toEqual(expected.recordId)
+    expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+  })
+
+  test('should transform pactbroker ALB log from S3', async () => {
+    const result = await handler(anS3AlbPactbrokerEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+    const expected = anS3AlbPactbrokerEvent.expected.records[0]
     expect(result.records[0].result).toEqual(expected.result)
     expect(result.records[0].recordId).toEqual(expected.recordId)
     expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,13 @@ function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVa
   }
 }
 
+function getAlbService(albName: string, environment: string): string {
+  return albName
+    .replace(`${environment}-`, '')
+    .replace('tooling-', '')
+    .replace('-alb', '')
+}
+
 function transformALBLog(data: S3LogRecord, envVars: EnvVars): TransformationResult {
   return {
     result: 'Ok',
@@ -213,7 +220,8 @@ function transformALBLog(data: S3LogRecord, envVars: EnvVars): TransformationRes
         event: log,
         fields: {
           account: envVars.account,
-          environment: envVars.environment
+          environment: envVars.environment,
+          service: getAlbService(data.ALB as string, envVars.environment)
         }
       }
     })


### PR DESCRIPTION
Add the name of the service to the Splunk record for ALB access logs.


### NOTES ###
Here is the list of ALB names we currently have.

```
➤➤ ~ $ for env in dev test staging prod deploy; do aws-vault exec pay-${env}-admin -- aws elbv2 describe-load-balancers  | jq '.LoadBalancers[].LoadBalancerName' -r; done
test-perf-1-webhooks-egress-nlb
test-12-egress-nlb
test-12-webhooks-egress-nlb
test-perf-1-egress-nlb
test-12-cardid-alb
test-12-frontend-alb
test-12-adminusers-alb
test-12-selfservice-alb
test-12-publicapi-alb
test-12-toolbox-alb
test-12-connector-alb
test-12-publicauth-alb
test-12-ledger-alb
test-12-products-alb
test-12-products-ui-alb
test-perf-1-connector-alb
test-perf-1-publicauth-alb
test-perf-1-toolbox-alb
test-perf-1-ledger-alb
test-perf-1-adminusers-alb
test-perf-1-products-alb
test-perf-1-selfservice-alb
test-perf-1-cardid-alb
test-perf-1-frontend-alb
test-perf-1-products-ui-alb
test-perf-1-publicapi-alb
test-12-notifications-alb
test-perf-1-notifications-alb
test-12-webhooks-alb
test-perf-1-webhooks-alb
staging-2-egress-nlb
staging-2-webhooks-egress-nlb
staging-2-toolbox-alb
staging-2-products-alb
staging-2-adminusers-alb
staging-2-ledger-alb
staging-2-frontend-alb
staging-2-products-ui-alb
staging-2-connector-alb
staging-2-publicauth-alb
staging-2-selfservice-alb
staging-2-cardid-alb
staging-2-publicapi-alb
staging-2-notifications-alb
staging-2-webhooks-alb
production-2-webhooks-egress-nlb
production-2-egress-nlb
production-2-selfservice-alb
production-2-adminusers-alb
production-2-cardid-alb
production-2-publicapi-alb
production-2-products-alb
production-2-publicauth-alb
production-2-products-ui-alb
production-2-frontend-alb
production-2-connector-alb
production-2-toolbox-alb
production-2-ledger-alb
production-2-notifications-alb
production-2-webhooks-alb
pay-cd-concourse-monitoring
pay-cd-concourse-web
deploy-tooling-pactbroker-alb
deploy-pushgateway-alb
deploy-tooling-stubs-alb
```