### PR TITLE
Pp 13603 add time stamps

### DIFF
--- a/spec/fixtures/application_fixtures.ts
+++ b/spec/fixtures/application_fixtures.ts
@@ -43,12 +43,12 @@ export const anApplicationLogCloudWatchEvent: Fixture = {
           {
             id: 'cloudwatch-log-message-id-1',
             timestamp: '1234',
-            message: 'Log event message 1'
+            message: '{"@timestamp": "2025-02-18T10:07:24.093Z","@version": 1, "container": "frontend", "environment": "test-12", "http_version": "1.0", "level": "INFO", "logger_name": "/app/app/middleware/logging-middleware.js", "message": "Request received", "method": "GET", "remote_address": "15.177.18.167", "response_time": "3.312 ms", "status_code": "200", "url": "/healthcheck", "user_agent": "Amazon-Route53-Health-Check-Service (ref 6b4f1794-fb11-4e80-bdde-241b02e47a79; report http://amzn.to/1vsZADi)", "x_request_id": "06d501244509bc2ce935318a9116496e"}'
           },
           {
             id: 'cloudwatch-log-gmessage-id-2',
             timestamp: '12345',
-            message: 'Log event message 2'
+            message: '{"@timestamp": "2025-02-18T10:11:24.093Z","@version": 1, "container": "frontend", "environment": "test-12", "http_version": "1.0", "level": "INFO", "logger_name": "/app/app/middleware/logging-middleware.js", "message": "Request received", "method": "GET", "remote_address": "15.177.18.167", "response_time": "3.312 ms", "status_code": "200", "url": "/healthcheck", "user_agent": "Amazon-Route53-Health-Check-Service (ref 6b4f1794-fb11-4e80-bdde-241b02e47a79; report http://amzn.to/1vsZADi)", "x_request_id": "06d501244509bc2ce935318a9116496e"}'
           }
         ]
       })).toString('base64')
@@ -66,12 +66,12 @@ export const anApplicationLogCloudWatchEvent: Fixture = {
           {
             id: 'cloudwatch-log-message-id-1',
             timestamp: '1234',
-            message: 'Log event message 1'
+            message: '{"container": "connector","status_code": 200,"method": "GET","x_request_id": "-","http_version": "HTTP/1.0","remote_address": "172.18.34.11","url": "/healthcheck","environment": "test-12","@timestamp": "2025-02-18T10:14:22.199+0000","@version": 1,"response_time": 31,"content_length": 249,"user_agent": "ELB-HealthChecker/2.0"}'
           },
           {
             id: 'cloudwatch-log-gmessage-id-2',
             timestamp: '12345',
-            message: 'Log event message 2'
+            message: '{"container": "connector","status_code": 200,"method": "GET","x_request_id": "-","http_version": "HTTP/1.0","remote_address": "172.18.34.11","url": "/healthcheck","environment": "test-12","@timestamp": "2025-02-18T10:15:22.199+0000","@version": 1,"response_time": 31,"content_length": 249,"user_agent": "ELB-HealthChecker/2.0"}'
           }
         ]
       })).toString('base64')
@@ -88,24 +88,26 @@ export const anApplicationLogCloudWatchEvent: Fixture = {
           source: 'app',
           sourcetype: 'ST004:application_json',
           index: 'pay_application',
-          event: 'Log event message 1',
+          event: '{"@timestamp": "2025-02-18T10:07:24.093Z","@version": 1, "container": "frontend", "environment": "test-12", "http_version": "1.0", "level": "INFO", "logger_name": "/app/app/middleware/logging-middleware.js", "message": "Request received", "method": "GET", "remote_address": "15.177.18.167", "response_time": "3.312 ms", "status_code": "200", "url": "/healthcheck", "user_agent": "Amazon-Route53-Health-Check-Service (ref 6b4f1794-fb11-4e80-bdde-241b02e47a79; report http://amzn.to/1vsZADi)", "x_request_id": "06d501244509bc2ce935318a9116496e"}',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'frontend'
-          }
+          },
+          time: 1739873244.093
         },
         {
           host: 'frontendECSTaskId',
           source: 'app',
           sourcetype: 'ST004:application_json',
           index: 'pay_application',
-          event: 'Log event message 2',
+          event: '{"@timestamp": "2025-02-18T10:11:24.093Z","@version": 1, "container": "frontend", "environment": "test-12", "http_version": "1.0", "level": "INFO", "logger_name": "/app/app/middleware/logging-middleware.js", "message": "Request received", "method": "GET", "remote_address": "15.177.18.167", "response_time": "3.312 ms", "status_code": "200", "url": "/healthcheck", "user_agent": "Amazon-Route53-Health-Check-Service (ref 6b4f1794-fb11-4e80-bdde-241b02e47a79; report http://amzn.to/1vsZADi)", "x_request_id": "06d501244509bc2ce935318a9116496e"}',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'frontend'
-          }
+          },
+          time: 1739873484.093
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }, {
@@ -117,24 +119,26 @@ export const anApplicationLogCloudWatchEvent: Fixture = {
           source: 'app',
           sourcetype: 'ST004:application_json',
           index: 'pay_application',
-          event: 'Log event message 1',
+          event: '{"container": "connector","status_code": 200,"method": "GET","x_request_id": "-","http_version": "HTTP/1.0","remote_address": "172.18.34.11","url": "/healthcheck","environment": "test-12","@timestamp": "2025-02-18T10:14:22.199+0000","@version": 1,"response_time": 31,"content_length": 249,"user_agent": "ELB-HealthChecker/2.0"}',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'connector'
-          }
+          },
+          time: 1739873662.199
         },
         {
           host: 'connectorECSTaskId',
           source: 'app',
           sourcetype: 'ST004:application_json',
           index: 'pay_application',
-          event: 'Log event message 2',
+          event: '{"container": "connector","status_code": 200,"method": "GET","x_request_id": "-","http_version": "HTTP/1.0","remote_address": "172.18.34.11","url": "/healthcheck","environment": "test-12","@timestamp": "2025-02-18T10:15:22.199+0000","@version": 1,"response_time": 31,"content_length": 249,"user_agent": "ELB-HealthChecker/2.0"}',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'connector'
-          }
+          },
+          time: 1739873722.199
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -44,7 +44,8 @@ export const aConcourseSyslogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739182596.000
         },
         {
           host: 'logStream',
@@ -56,7 +57,8 @@ export const aConcourseSyslogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739182596.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -44,7 +44,8 @@ export const aPrometheusSyslogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1739182596.000
         },
         {
           host: 'logStream',
@@ -56,7 +57,8 @@ export const aPrometheusSyslogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1739182596.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/squid_fixtures.ts
+++ b/spec/fixtures/squid_fixtures.ts
@@ -44,7 +44,8 @@ export const aSquidEgressAccessLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'egress'
-          }
+          },
+          time: 1739285977.555
         },
         {
           host: 'logStream',
@@ -56,7 +57,8 @@ export const aSquidEgressAccessLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'egress'
-          }
+          },
+          time: 1739285977.093
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -233,7 +235,8 @@ export const aSquidWebhookEgressAccessLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'webhook-egress'
-          }
+          },
+          time: 1739285977.555
         },
         {
           host: 'logStream',
@@ -245,7 +248,8 @@ export const aSquidWebhookEgressAccessLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'webhook-egress'
-          }
+          },
+          time: 1739285977.093
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]


### PR DESCRIPTION
First of many PRs to add in extracting time stamps from our log messages in the transformation lambda. There is some temporary code, clearly marked with `TODO` to enable adding time stamps per log type without needing to change all the tests at once. When we're done we'll remove the optionality on `SplunkRecord.time` field.

Besides needing to add in all the other log types we'll also have default handling for when we cannot extract a time from the log and I'll add tests for those scenarios when we do that work. At present the new tests are for the happy paths until we have logic to handle the less happy ones :) 

### Notes ###
Considering moving some of the time extraction into its own file, but will see how it grows as we add other log types...
