### PR TITLE
Pp 13603 add time stamps

### DIFF
--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -337,7 +337,8 @@ export const aConcourseApplicationCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739188215.965
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -198,7 +198,8 @@ export const aConcourseKernCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739185190.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -104,7 +104,8 @@ export const aConcourseAuditCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739184096.304
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -151,7 +151,8 @@ export const aConcourseAuthCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1739157038.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -104,7 +104,8 @@ export const aPrometheusAuditCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1739184096.304
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -151,7 +151,8 @@ export const aPrometheusAuthCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1739157038.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -198,7 +198,8 @@ export const aPrometheusKernCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1739185190.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,16 @@ function extractAuditLogTime(log: string): number | undefined {
   return Number(extractedTime[1])
 }
 
+function extractConcourseLogTime(log: string): number | undefined {
+  const regex = /"timestamp"\s*:\s*"(.*?)"/
+  const extractedTime = regexTimeFromLog(regex, log)
+  if (extractedTime === undefined) {
+    return undefined
+  }
+
+  return parseStringToEpoch(extractedTime[1])
+}
+
 // TODO: whilst adding this in it'll return undefined if not yet implemented for log type.
 function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | undefined {
   switch (logType) {
@@ -230,6 +240,8 @@ function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | un
       return extractSysLogTime(log)
     case CloudWatchLogTypes.audit:
       return extractAuditLogTime(log)
+    case CloudWatchLogTypes.concourse:
+      return extractConcourseLogTime(log)
     default:
       console.log(`Time stamp parsing not yet implemented for "${logType}" log types.`)
       return undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,8 @@ function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | un
       return extractSysLogTime(log)
     case CloudWatchLogTypes.audit:
       return extractAuditLogTime(log)
+    case CloudWatchLogTypes.auth:
+      return extractSysLogTime(log)
     default:
       console.log(`Time stamp parsing not yet implemented for "${logType}" log types.`)
       return undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,11 +225,11 @@ function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | un
     case CloudWatchLogTypes.squid:
       return extractSquidLogTime(log)
     case CloudWatchLogTypes.syslog:
+    case CloudWatchLogTypes.auth:
+    case CloudWatchLogTypes.kern:
       return extractSysLogTime(log)
     case CloudWatchLogTypes.audit:
       return extractAuditLogTime(log)
-    case CloudWatchLogTypes.auth:
-      return extractSysLogTime(log)
     default:
       console.log(`Time stamp parsing not yet implemented for "${logType}" log types.`)
       return undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,16 @@ function extractSysLogTime(log: string): number | undefined {
   return parseStringToEpoch(dateTimeString)
 }
 
+function extractAuditLogTime(log: string): number | undefined {
+  const regex = /msg=audit\((\d+\.\d{3}):\d+\)/
+  const extractedTime = regexTimeFromLog(regex, log)
+  if (extractedTime === undefined) {
+    return undefined
+  }
+
+  return Number(extractedTime[1])
+}
+
 // TODO: whilst adding this in it'll return undefined if not yet implemented for log type.
 function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | undefined {
   switch (logType) {
@@ -216,6 +226,8 @@ function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): number | un
       return extractSquidLogTime(log)
     case CloudWatchLogTypes.syslog:
       return extractSysLogTime(log)
+    case CloudWatchLogTypes.audit:
+      return extractAuditLogTime(log)
     default:
       console.log(`Time stamp parsing not yet implemented for "${logType}" log types.`)
       return undefined


### PR DESCRIPTION
Next batch of time extraction. 

I'm keeping an eye on how large `index.ts` is getting and will consider splitting the time functions out into a separate file if necessary later on. The regex for the audit logs of `/msg=audit\((\d+\.\d{3}):\d+\)/` is based upon a message including something like `msg=audit(1739184096.304:468)` which seems pretty safe based on looking at the formats, it could be made a little loser if we just looked for `\(\d+\.\d{3}):\d+\`, seems a balance between making sure we get what we expect versus becoming too brittle to future log format changes 🤷 