### PR TITLE
PP-13606 Add Nginx Error Logs

### DIFF
--- a/spec/fixtures/nginx_fixtures.ts
+++ b/spec/fixtures/nginx_fixtures.ts
@@ -129,3 +129,122 @@ export const anNginxReverseProxyCloudWatchEvent: Fixture = {
     }]
   }
 }
+
+export const anNginxReverProxyErrorCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'LogEvent-1',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'test-12_nginx-reverse-proxy_frontend',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'a-naxsi-block',
+            timestamp: '1234',
+            message: '2025/02/25 11:09:14 [error] 51#51: *81035 NAXSI_FMT: ip=107.174.11.239&server=0.0.0.0&uri=/something&vers=1.3&total_processed=81047&total_blocked=2081&config=block&zone0=BODY&id0=11&var_name0=, client: 0.0.0.0, server: $host, request: "POST /something HTTP/1.1", host: "0.0.0.0."'
+          },
+          {
+            id: 'some-warn-level-message',
+            timestamp: '12345',
+            message: '2025/02/25 11:10:14 [warn]'
+          },
+          {
+            id: 'some-crit-level-message',
+            timestamp: '12345',
+            message: '2025/02/25 11:10:15 [crit]'
+          },
+          {
+            id: 'some-alert-level-message',
+            timestamp: '12345',
+            message: '2025/02/25 11:10:16 [alert]'
+          },
+          {
+            id: 'some-emerg-level-message',
+            timestamp: '12345',
+            message: '2025/02/25 11:10:17 [emerg]'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'LogEvent-1',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: '2025/02/25 11:09:14 [error] 51#51: *81035 NAXSI_FMT: ip=107.174.11.239&server=0.0.0.0&uri=/something&vers=1.3&total_processed=81047&total_blocked=2081&config=block&zone0=BODY&id0=11&var_name0=, client: 0.0.0.0, server: $host, request: "POST /something HTTP/1.1", host: "0.0.0.0."',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          },
+          time: 1740481754.000
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: '2025/02/25 11:10:14 [warn]',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          },
+          time: 1740481814.000
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: '2025/02/25 11:10:15 [crit]',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          },
+          time: 1740481815.000
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: '2025/02/25 11:10:16 [alert]',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          },
+          time: 1740481816.000
+        },
+        {
+          host: 'logStream',
+          source: 'nginx-reverse-proxy',
+          sourcetype: 'nginx:plus:kv',
+          index: 'pay_ingress',
+          event: '2025/02/25 11:10:17 [emerg]',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'frontend'
+          },
+          time: 1740481817.000
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -33,6 +33,7 @@ import {
 
 import {
   anNginxForwardProxyCloudWatchEvent,
+  anNginxReverProxyErrorCloudWatchEvent,
   anNginxReverseProxyCloudWatchEvent
 } from './fixtures/nginx_fixtures'
 
@@ -83,11 +84,18 @@ describe('Processing CloudWatchLogEvents', () => {
       expect(result.records[0].recordId).toEqual(expected.recordId)
       expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
     })
-
     test('should transform nginx reverse proxy logs from CloudWatch', async () => {
       const result = await handler(anNginxReverseProxyCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
       const expected = anNginxReverseProxyCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+    test('should transform nginx error logs, including naxsi, from CloudWatch', async () => {
+      const result = await handler(anNginxReverProxyErrorCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = anNginxReverProxyErrorCloudWatchEvent.expected.records[0]
       expect(result.records[0].result).toEqual(expected.result)
       expect(result.records[0].recordId).toEqual(expected.recordId)
       expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,13 @@ function extractCloudTrailLogTime(log: string): number | undefined {
 }
 
 function extractNginxKvLogTime(log: string): number | undefined {
-  const regex = /time_local="(?<day>\d+)\/(?<month>\w+)\/(?<year>\d{4}):(?<time>.*?)"/
+  let regex: RegExp
+  if (log.match(/\[error|warn|crit|alert|emerg\]/) !== null) {
+    regex = /^\s?(?<year>\d+)\/(?<month>\d+)\/(?<day>\d+) (?<time>.*?) /
+  } else {
+    regex = /time_local="(?<day>\d+)\/(?<month>\w+)\/(?<year>\d{4}):(?<time>.*?)"/
+  }
+
   const extractedTime = regexTimeFromLog(regex, log)
   if (extractedTime === undefined) {
     return undefined


### PR DESCRIPTION
Add test cases and time extraction for Nginx error logs, including warn, crit and alert. These logs include the Naxsi block log lines and have a different time format.