### PR TITLE
Pp 13603 add time stamps

### DIFF
--- a/spec/fixtures/concourse_fixtures.ts
+++ b/spec/fixtures/concourse_fixtures.ts
@@ -223,7 +223,7 @@ export const aConcourseDmesgCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495826,
             message: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes'
           }
         ]
@@ -245,7 +245,8 @@ export const aConcourseDmesgCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1740495826
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -269,7 +270,7 @@ export const aConcourseAptCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495811,
             message: 'Commandline: apt-get install --yes auditd'
           }
         ]
@@ -291,7 +292,8 @@ export const aConcourseAptCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'concourse'
-          }
+          },
+          time: 1740495811
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/prometheus_fixtures.ts
+++ b/spec/fixtures/prometheus_fixtures.ts
@@ -223,7 +223,7 @@ export const aPrometheusDmesgCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495790,
             message: '[    9.105692] kernel: Btrfs loaded, zoned=yes, fsverity=yes'
           }
         ]
@@ -245,7 +245,8 @@ export const aPrometheusDmesgCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1740495790
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -269,7 +270,7 @@ export const aPrometheusAptCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495771,
             message: 'Commandline: apt-get install --yes auditd'
           }
         ]
@@ -291,7 +292,8 @@ export const aPrometheusAptCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'prometheus'
-          }
+          },
+          time: 1740495771
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/squid_fixtures.ts
+++ b/spec/fixtures/squid_fixtures.ts
@@ -82,12 +82,12 @@ export const aSquidEgressCacheLogCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495625,
             message: '2025/02/10 16:52:36| Preparing for shutdown after 61285 requests'
           },
           {
             id: 'cloudwatch-log-gmessage-id-2',
-            timestamp: '12345',
+            timestamp: 1740495626,
             message: '2025/02/10 16:52:35| Waiting 30 seconds for active connections to finish'
           }
         ]
@@ -109,7 +109,8 @@ export const aSquidEgressCacheLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'egress'
-          }
+          },
+          time: 1740495625
         },
         {
           host: 'logStream',
@@ -121,7 +122,8 @@ export const aSquidEgressCacheLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'egress'
-          }
+          },
+          time: 1740495626
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -145,13 +147,13 @@ export const aSquidWebhookEgressCacheLogCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495581,
             message: '    listening port: 0.0.0.0:8080'
           },
           {
             id: 'cloudwatch-log-gmessage-id-2',
-            timestamp: '12345',
-            message: '025/02/10 16:52:36| Closing HTTP(S) port 0.0.0.0:8080'
+            timestamp: 1740495582,
+            message: '2025/02/10 16:52:36| Closing HTTP(S) port 0.0.0.0:8080'
           }
         ]
       })).toString('base64')
@@ -172,19 +174,21 @@ export const aSquidWebhookEgressCacheLogCloudWatchEvent: Fixture = {
             account: 'test',
             environment: 'test-12',
             service: 'webhook-egress'
-          }
+          },
+          time: 1740495581
         },
         {
           host: 'logStream',
           source: 'squid',
           sourcetype: 'ST004:squid:cache',
           index: 'pay_egress',
-          event: '025/02/10 16:52:36| Closing HTTP(S) port 0.0.0.0:8080',
+          event: '2025/02/10 16:52:36| Closing HTTP(S) port 0.0.0.0:8080',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'webhook-egress'
-          }
+          },
+          time: 1740495582
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -208,12 +212,12 @@ export const aSquidWebhookEgressAccessLogCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495625,
             message: '1739285977.555   6074 172.18.4.240 TCP_TUNNEL/200 7095 CONNECT logs.eu-west-1.amazonaws.com:443 - HIER_DIRECT/172.18.2.195 -'
           },
           {
             id: 'cloudwatch-log-gmessage-id-2',
-            timestamp: '12345',
+            timestamp: 1740495626,
             message: '1739285977.093   6099 172.18.4.240 TCP_TUNNEL/200 7095 CONNECT logs.eu-west-1.amazonaws.com:443 - HIER_DIRECT/172.18.2.195 -'
           }
         ]

--- a/spec/fixtures/squid_fixtures.ts
+++ b/spec/fixtures/squid_fixtures.ts
@@ -110,7 +110,7 @@ export const aSquidEgressCacheLogCloudWatchEvent: Fixture = {
             environment: 'test-12',
             service: 'egress'
           },
-          time: 1740495625
+          time: 1739206356.000
         },
         {
           host: 'logStream',
@@ -123,7 +123,7 @@ export const aSquidEgressCacheLogCloudWatchEvent: Fixture = {
             environment: 'test-12',
             service: 'egress'
           },
-          time: 1740495626
+          time: 1739206355.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -188,7 +188,7 @@ export const aSquidWebhookEgressCacheLogCloudWatchEvent: Fixture = {
             environment: 'test-12',
             service: 'webhook-egress'
           },
-          time: 1740495582
+          time: 1739206356.000
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/spec/fixtures/vpcflowlog_fixtures.ts
+++ b/spec/fixtures/vpcflowlog_fixtures.ts
@@ -17,27 +17,27 @@ export const aMultiLogVpcFlowLogCloudWatchEvent: Fixture = {
         logEvents: [
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495533,
             message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 6 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is TCP
           },
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495533,
             message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 1 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is ICMP
           },
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495533,
             message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 17 17 5466 1739358222 1739358234 ACCEPT OK' // <-- filtered because it is UDP
           },
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495533,
             message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 2 17 5466 1739358222 1739358234 REJECT OK' // <-- filtered because it is REJECT
           },
           {
             id: 'cloudwatch-log-message-id-1',
-            timestamp: '1234',
+            timestamp: 1740495533,
             message: '2 223851549868 eni-0eda3cf860c2573f2 172.18.96.226 172.18.2.133 34238 443 2 17 5466 1739358222 1739358234 ACCEPT OK' // <-- This should go to Splunk
           }
         ]
@@ -58,7 +58,8 @@ export const aMultiLogVpcFlowLogCloudWatchEvent: Fixture = {
           fields: {
             account: 'test',
             environment: 'test-12'
-          }
+          },
+          time: 1740495533
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type TransformationResult = {
   splunkRecords: SplunkRecord[]
 }
 
-type SplunkRecord = {
+export type SplunkRecord = {
   // TODO: this is optional whilst we add in time stamp parsing.
   time?: number
   host: string
@@ -321,11 +321,11 @@ function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVa
       fields
     }
 
-    // TODO: whilst adding time parsing this is optional.
-    const time = parseTimeFromLog(event.message, logType)
-    if (time !== undefined) {
-      splunkRecord.time = time
+    let time = parseTimeFromLog(event.message, logType)
+    if (time === undefined) {
+      time = event.timestamp
     }
+    splunkRecord.time = time
 
     return splunkRecord
   })


### PR DESCRIPTION
Two small-ish commits
1. Begin adding default time logic. N.B: I should have begun adding the default time logic in the order of precedence but regrettably I didn't, so the next commit will add the default behaviour that will use the previous log line's time before using the cloudwatch event time which is added herein.
2. Extract squid cache log time if it exists.