### PR TITLE
PP-13603 Add Time Extraction For ALB Logs

### DIFF
--- a/spec/fixtures/s3_fixtures.ts
+++ b/spec/fixtures/s3_fixtures.ts
@@ -6,7 +6,7 @@ export const anS3AlbEvent: Fixture = {
     invocationId: 'someId',
     region: 'eu-west-1',
     records: [{
-      approximateArrivalTimestamp: 1234,
+      approximateArrivalTimestamp: 1740578973,
       recordId: 'LogEvent-1',
       data: Buffer.from(JSON.stringify(
         {
@@ -17,7 +17,11 @@ export const anS3AlbEvent: Fixture = {
           ALB: 'test-12-products-ui-alb',
           AWSAccountID: '223851549868',
           AWSAccountName: 'pay-test',
-          Logs: ['alb log line 1', 'alb log line 2']
+          Logs: [
+            'log-1 should use approximateArrivalTimestamp',
+            'log-2 should use time 2025-02-26T14:05:00.801440Z ',
+            'log-3 should use time from log-2'
+          ]
         }
       )).toString('base64')
     }]
@@ -32,23 +36,37 @@ export const anS3AlbEvent: Fixture = {
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
-          event: 'alb log line 1',
+          event: 'log-1 should use approximateArrivalTimestamp',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'products-ui'
-          }
+          },
+          time: 1740578973
         }, {
           host: 'test-12-products-ui-alb',
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
-          event: 'alb log line 2',
+          event: 'log-2 should use time 2025-02-26T14:05:00.801440Z ',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'products-ui'
-          }
+          },
+          time: 1740578700.801
+        }, {
+          host: 'test-12-products-ui-alb',
+          source: 'ALB',
+          sourcetype: 'aws:elb:accesslogs',
+          index: 'pay_ingress',
+          event: 'log-3 should use time from log-2',
+          fields: {
+            account: 'test',
+            environment: 'test-12',
+            service: 'products-ui'
+          },
+          time: 1740578700.801
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]
@@ -72,7 +90,7 @@ export const anS3AlbPactbrokerEvent: Fixture = {
           ALB: 'test-12-tooling-pactbroker-alb',
           AWSAccountID: '223851549868',
           AWSAccountName: 'pay-test',
-          Logs: ['alb log line 1', 'alb log line 2']
+          Logs: ['alb log line 1 2025-02-26T14:05:00.801440Z', 'alb log line 2 2025-02-26T14:05:10.801440Z']
         }
       )).toString('base64')
     }]
@@ -87,23 +105,25 @@ export const anS3AlbPactbrokerEvent: Fixture = {
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
-          event: 'alb log line 1',
+          event: 'alb log line 1 2025-02-26T14:05:00.801440Z',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'pactbroker'
-          }
+          },
+          time: 1740578700.801
         }, {
           host: 'test-12-tooling-pactbroker-alb',
           source: 'ALB',
           sourcetype: 'aws:elb:accesslogs',
           index: 'pay_ingress',
-          event: 'alb log line 2',
+          event: 'alb log line 2 2025-02-26T14:05:10.801440Z',
           fields: {
             account: 'test',
             environment: 'test-12',
             service: 'pactbroker'
-          }
+          },
+          time: 1740578710.801
         }
       ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
     }]


### PR DESCRIPTION
Set the time when transforming ALB logs, in order of preference:
1. Use the time extracted from the log line
2. Use the time from the previous log line
3. Use the approximateArrivalTimestamp from the Firehose event.

### NOTES ###
I'll put in the same for S3 events before embarking on a refactor. Although we had a useful chat about using fixtures or not, it does seem that some test cases are "hidden" in the fixtures, but with the benefit of less setup in the tests which had made them harder to comprehend before. Once the time logic is finished I might experiment with some different ideas time permitting.  