### PR TITLE
PP-13731: Make ENVIRONMENT env var optional, and fail if needed

### DIFF
--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -457,11 +457,11 @@ describe('General processing', () => {
     expect(result.records[0].recordId).toEqual('testRecordId')
   })
 
-  test('should error if ENVIRONMENT env var is not set', async () => {
-    process.env.AWS_ACCOUNT_NAME = 'test'
-    process.env.AWS_ACCOUNT_ID = '223851549868'
-    process.env.ENVIRONMENT = ''
-    await expect(async () => await handler(aCloudWatchEventWith([]), mockContext, mockCallback) as FirehoseTransformationResult).rejects.toThrow('"ENVIRONMENT" env var is not set')
+  test('should error if ENVIRONMENT env var is not set, but is required', async () => {
+    process.env.ENVIRONMENT = ""
+    const result = await handler(anApplicationLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+    expect(result.records[0].result).toEqual('ProcessingFailed')
+    expect(result.records[0].recordId).toEqual('LogEvent-1')
   })
 
   test('should error if AWS_ACCOUNT_NAME env var is not set', async () => {
@@ -477,4 +477,5 @@ describe('General processing', () => {
     process.env.AWS_ACCOUNT_ID = ''
     await expect(async () => await handler(aCloudWatchEventWith([]), mockContext, mockCallback) as FirehoseTransformationResult).rejects.toThrow('"AWS_ACCOUNT_ID" env var is not set')
   })
+
 })

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -458,7 +458,7 @@ describe('General processing', () => {
   })
 
   test('should error if ENVIRONMENT env var is not set, but is required', async () => {
-    process.env.ENVIRONMENT = ""
+    process.env.ENVIRONMENT = ''
     const result = await handler(anApplicationLogCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
     expect(result.records[0].result).toEqual('ProcessingFailed')
     expect(result.records[0].recordId).toEqual('LogEvent-1')
@@ -477,5 +477,4 @@ describe('General processing', () => {
     process.env.AWS_ACCOUNT_ID = ''
     await expect(async () => await handler(aCloudWatchEventWith([]), mockContext, mockCallback) as FirehoseTransformationResult).rejects.toThrow('"AWS_ACCOUNT_ID" env var is not set')
   })
-
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,16 @@ function getMandatoryEnvVar(varName: string): string {
 }
 
 function getEnvVars(): EnvVars {
-  return {
-    environment: getMandatoryEnvVar('ENVIRONMENT'),
+  const envVars: EnvVars = {
     aws_account_name: getMandatoryEnvVar('AWS_ACCOUNT_NAME'),
     aws_account_id: getMandatoryEnvVar('AWS_ACCOUNT_ID')
   }
+
+  if (Object.hasOwn(process.env, "ENVIRONMENT")) {
+    envVars.environment = process.env.ENVIRONMENT
+  }
+
+  return envVars
 }
 
 function debugTransformation(records: FirehoseTransformationResultRecord[]): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ function getEnvVars(): EnvVars {
     aws_account_id: getMandatoryEnvVar('AWS_ACCOUNT_ID')
   }
 
-  if (Object.hasOwn(process.env, "ENVIRONMENT")) {
+  if (Object.hasOwn(process.env, 'ENVIRONMENT')) {
     envVars.environment = process.env.ENVIRONMENT
   }
 

--- a/src/transformData.ts
+++ b/src/transformData.ts
@@ -21,6 +21,10 @@ function transformALBLog(data: S3LogRecord, envVars: EnvVars, approximateArrival
       time = approximateArrivalTimestamp
     }
 
+    if (envVars.environment === undefined) {
+      throw new Error(`"ENVIRONMENT" env var is not set`)
+    }
+
     return {
       host: data.ALB as string,
       source: 'ALB',
@@ -98,7 +102,7 @@ function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVa
   }
 
   if (logType !== CloudWatchLogTypes['cloudtrail']) {
-    if (envVars.environment === undefined || envVars.environment === "") {
+    if (envVars.environment === undefined || envVars.environment === '') {
       throw new Error(`"ENVIRONMENT" env var is not set`)
     }
     fields.environment = envVars.environment

--- a/src/transformData.ts
+++ b/src/transformData.ts
@@ -98,6 +98,9 @@ function transformCloudWatchData(data: CloudWatchLogsDecodedData, envVars: EnvVa
   }
 
   if (logType !== CloudWatchLogTypes['cloudtrail']) {
+    if (envVars.environment === undefined || envVars.environment === "") {
+      throw new Error(`"ENVIRONMENT" env var is not set`)
+    }
     fields.environment = envVars.environment
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export type S3LogRecord = {
 }
 
 export type EnvVars = {
-  environment: string
+  environment?: string
   aws_account_name: string
   aws_account_id: string
 }


### PR DESCRIPTION
For delivery of account level things (s3 logs and cloudtrail) there is no ENVIRONMENT to set, so it needs to be optional