### PR TITLE
PP-14422 Add AWS WAF Transformation

### DIFF
--- a/spec/fixtures/aws_waf_log_fixtures.ts
+++ b/spec/fixtures/aws_waf_log_fixtures.ts
@@ -1,0 +1,47 @@
+import { Fixture } from './general_fixtures'
+
+export const anWAFCloudWatchEvent: Fixture = {
+  input: {
+    deliveryStreamArn: 'someDeliveryStreamArn',
+    invocationId: 'someId',
+    region: 'eu-west-1',
+    records: [{
+      approximateArrivalTimestamp: 1234,
+      recordId: 'record-id-waf-logs',
+      data: Buffer.from(JSON.stringify({
+        owner: '223851549868',
+        logGroup: 'aws-waf-logs-test-12',
+        logStream: 'logStream',
+        subscriptionFilters: [],
+        messageType: 'DATA_MESSAGE',
+        logEvents: [
+          {
+            id: 'cloudwatch-log-message-id-1',
+            timestamp: 1740495533,
+            message: '{"timestamp":1756899436824,"some":"json"}'
+          }
+        ]
+      })).toString('base64')
+    }]
+  },
+  expected: {
+    records: [{
+      result: 'Ok',
+      recordId: 'record-id-waf-logs',
+      data: Buffer.from([
+        {
+          host: 'logStream',
+          source: 'waf',
+          sourcetype: 'generic_single_line',
+          index: 'pay_ingress',
+          event: '{"timestamp":1756899436824,"some":"json"}',
+          fields: {
+            account: 'test',
+            environment: 'test-12'
+          },
+          time: 1756899436824
+        }
+      ].map(x => JSON.stringify(x)).join('\n')).toString('base64')
+    }]
+  }
+}

--- a/spec/index.test.ts
+++ b/spec/index.test.ts
@@ -63,6 +63,9 @@ import {
   aMultiLogVpcFlowLogAllFilteredCloudWatchEvent,
   aMultiLogVpcFlowLogCloudWatchEvent
 } from './fixtures/vpcflowlog_fixtures'
+import {
+  anWAFCloudWatchEvent
+} from './fixtures/aws_waf_log_fixtures'
 import { SplunkRecord } from '../src/types'
 
 process.env.ENVIRONMENT = 'test-12'
@@ -326,6 +329,17 @@ describe('Processing CloudWatchLogEvents', () => {
       const result = await handler(aMultiLogVpcFlowLogAllFilteredCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
 
       const expected = aMultiLogVpcFlowLogAllFilteredCloudWatchEvent.expected.records[0]
+      expect(result.records[0].result).toEqual(expected.result)
+      expect(result.records[0].recordId).toEqual(expected.recordId)
+      expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())
+    })
+  })
+
+  describe('From AWS WAF', () => {
+    test('should send the log correctly transformed', async () => {
+      const result = await handler(anWAFCloudWatchEvent.input, mockContext, mockCallback) as FirehoseTransformationResult
+
+      const expected = anWAFCloudWatchEvent.expected.records[0]
       expect(result.records[0].result).toEqual(expected.result)
       expect(result.records[0].recordId).toEqual(expected.recordId)
       expect(Buffer.from(result.records[0].data as string, 'base64').toString()).toEqual(Buffer.from(expected.data as string, 'base64').toString())

--- a/src/extractTime.ts
+++ b/src/extractTime.ts
@@ -79,6 +79,16 @@ export function extractAuditLogTime(log: string): number | undefined {
   return Number(extractedTime[1])
 }
 
+export function extractWAFLogTime(log: string): number | undefined {
+  const regex = /"timestamp"\s*:\s*(.*?),/
+  const extractedTime = regexTimeFromLog(regex, log)
+  if (extractedTime === undefined) {
+    return undefined
+  }
+
+  return parseInt(extractedTime[1])
+}
+
 export function extractConcourseLogTime(log: string): number | undefined {
   const regex = /"timestamp"\s*:\s*"(.*?)"/
   const extractedTime = regexTimeFromLog(regex, log)
@@ -175,5 +185,7 @@ export function parseTimeFromLog(log: string, logType: CloudWatchLogTypes): numb
       return extractNginxKvLogTime(log)
     case CloudWatchLogTypes.cloudtrail:
       return extractCloudTrailLogTime(log)
+    case CloudWatchLogTypes.waf:
+      return extractWAFLogTime(log)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,5 +52,6 @@ export enum CloudWatchLogTypes {
   'nginx-reverse-proxy',
   'syslog',
   'squid',
-  'vpc-flow-logs'
+  'vpc-flow-logs',
+  'waf'
 }


### PR DESCRIPTION
The Cloudwatch Log Group for AWS WAF must begin `aws-waf-logs-` which breaks our naming convention and requires some new bespoke logic. There is no AWS WAF source type in Splunk so this uses the generic_single_line for now.